### PR TITLE
Fix autoprovision

### DIFF
--- a/client.go
+++ b/client.go
@@ -156,7 +156,7 @@ func Init(file string, ServerIndex string) {
 			newConfigPath := Config.Global.Software.AutoProvisioning.SaveFilePath + Config.Global.Software.AutoProvisioning.SaveFilename
 			log.Printf("info: Loading provisioned config from: %s", newConfigPath)
 			ConfigXMLFile = newConfigPath
-			readxmlconfig(ConfigXMLFile, false)
+			readxmlconfig(ConfigXMLFile, true)
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -156,7 +156,7 @@ func Init(file string, ServerIndex string) {
 			newConfigPath := Config.Global.Software.AutoProvisioning.SaveFilePath + Config.Global.Software.AutoProvisioning.SaveFilename
 			log.Printf("info: Loading provisioned config from: %s", newConfigPath)
 			ConfigXMLFile = newConfigPath
-			readxmlconfig(ConfigXMLFile, true)
+			readxmlconfig(ConfigXMLFile, false)
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -156,7 +156,11 @@ func Init(file string, ServerIndex string) {
 			newConfigPath := Config.Global.Software.AutoProvisioning.SaveFilePath + Config.Global.Software.AutoProvisioning.SaveFilename
 			log.Printf("info: Loading provisioned config from: %s", newConfigPath)
 			ConfigXMLFile = newConfigPath
-			readxmlconfig(ConfigXMLFile, false)
+			readxmlconfig(ConfigXMLFile, true)
+			log.Printf("debug: After autoprovisioning - Name[%d]: %s", AccountIndex, Name[AccountIndex])
+			log.Printf("debug: After autoprovisioning - Server[%d]: %s", AccountIndex, Server[AccountIndex])
+			log.Printf("debug: After autoprovisioning - Username[%d]: %s", AccountIndex, Username[AccountIndex])
+
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -153,8 +153,9 @@ func Init(file string, ServerIndex string) {
 		if err != nil {
 			FatalCleanUp("Error from AutoProvisioning Module " + err.Error())
 		} else {
-			log.Println("info: Loading XML Config")
-			ConfigXMLFile = file
+			newConfigPath := Config.Global.Software.AutoProvisioning.SaveFilePath + Config.Global.Software.AutoProvisioning.SaveFilename
+			log.Printf("info: Loading provisioned config from: %s", newConfigPath)
+			ConfigXMLFile = newConfigPath
 			readxmlconfig(ConfigXMLFile, false)
 		}
 	}

--- a/xmlparser.go
+++ b/xmlparser.go
@@ -825,6 +825,38 @@ var (
 var StreamTracker = map[uint32]streamTrackerStruct{}
 var DMOSetup sa818.DMOSetupStruct
 
+func populateGlobalAccountVars(cfg *ConfigStruct) {
+	Name = []string{}
+	Server = []string{}
+	Username = []string{}
+	Password = []string{}
+	Insecure = []bool{}
+	Register = []bool{}
+	Certificate = []string{}
+	Channel = []string{}
+	Ident = []string{}
+	Tokens = []gumble.AccessTokens{}
+	VT = []VTStruct{}
+	AccountCount = 0
+
+	for _, account := range cfg.Accounts.Account {
+		if account.Default {
+			Name = append(Name, account.Name)
+			Server = append(Server, account.ServerAndPort)
+			Username = append(Username, account.UserName)
+			Password = append(Password, account.Password)
+			Insecure = append(Insecure, account.Insecure)
+			Register = append(Register, account.Register)
+			Certificate = append(Certificate, account.Certificate)
+			Channel = append(Channel, account.Channel)
+			Ident = append(Ident, account.Ident)
+			Tokens = append(Tokens, account.Tokens.Token)
+			VT = append(VT, VTStruct(account.Voicetargets))
+			AccountCount++
+		}
+	}
+}
+
 func readxmlconfig(file string, reloadxml bool) error {
 	var ReConfig ConfigStruct
 
@@ -851,24 +883,12 @@ func readxmlconfig(file string, reloadxml bool) error {
 	CheckConfigSanity(reloadxml)
 
 	if !reloadxml {
-		for _, account := range Config.Accounts.Account {
-			if account.Default {
-				Name = append(Name, account.Name)
-				Server = append(Server, account.ServerAndPort)
-				Username = append(Username, account.UserName)
-				Password = append(Password, account.Password)
-				Insecure = append(Insecure, account.Insecure)
-				Register = append(Register, account.Register)
-				Certificate = append(Certificate, account.Certificate)
-				Channel = append(Channel, account.Channel)
-				Ident = append(Ident, account.Ident)
-				Tokens = append(Tokens, account.Tokens.Token)
-				VT = append(VT, VTStruct(account.Voicetargets))
-				//ListenChannelNameList = append(ListenChannelNameList, account.Listentochannels.ChannelNames...)
-				AccountCount++
-			}
-		}
+		populateGlobalAccountVars(&Config)
+	} else {
+		Config = ReConfig
+		populateGlobalAccountVars(&Config)
 	}
+
 	for _, kMainCommands := range Config.Global.Hardware.Keyboard.Command {
 		if kMainCommands.Enabled {
 			if kMainCommands.Ttykeyboard.Enabled {

--- a/xmlparser.go
+++ b/xmlparser.go
@@ -886,6 +886,7 @@ func readxmlconfig(file string, reloadxml bool) error {
 		populateGlobalAccountVars(&Config)
 	} else {
 		Config = ReConfig
+		log.Printf("debug: New Config: %v", Config)
 		populateGlobalAccountVars(&Config)
 	}
 


### PR DESCRIPTION
Fixes an issue where even after autoprovisioning, the old account config was used when connecting to a server in `ClientStart` by making sure the initial configs data is overridden with the autoprovisioned config after it has been loaded into memory.